### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -5,6 +5,8 @@
 # This workflow will install a prebuilt Ruby version, install dependencies, and
 # run tests and linters.
 name: "Ruby on Rails CI"
+permissions:
+  contents: read
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/helloworld9991/hello/security/code-scanning/1](https://github.com/helloworld9991/hello/security/code-scanning/1)

To fix this issue, we need to add an explicit `permissions` block to the workflow. Since the workflow description mentions installing Ruby, dependencies, and running tests and linters, it likely doesn't require write access to repository resources. Therefore, the permissions should be set to `contents: read` at the workflow level to minimize access while allowing necessary read-only operations.

Changes will be made as follows:
1. Add a `permissions` block at the workflow level (before `jobs`) to specify `contents: read`.
2. Ensure that the `permissions` block provides only the access required for the workflow to function properly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
